### PR TITLE
Fix compiling with no_metrics feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ readme = "README.md"
 
 [dependencies]
 libc = "0.2.66"
+
+[features]
+no_metrics = []

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -106,6 +106,8 @@ impl Histogram {
                 .fetch_add(1, Ordering::Relaxed)
                 + 1
         }
+        #[cfg(feature = "no_metrics")]
+        0
     }
 
     /// Retrieve a percentile [0-100]. Returns NAN if no metrics have been

--- a/src/io_uring/mod.rs
+++ b/src/io_uring/mod.rs
@@ -176,6 +176,7 @@ impl Drop for Uring {
         }
 
         if self.config.print_profile_on_drop {
+            #[cfg(not(feature = "no_metrics"))]
             M.print_profile();
         }
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -106,6 +106,7 @@ pub struct Metrics {
 
 impl Drop for Metrics {
     fn drop(&mut self) {
+        #[cfg(not(feature = "no_metrics"))]
         self.print_profile()
     }
 }


### PR DESCRIPTION
Was profiling nop_spewwa, added more `cfg` attributes to avoid metrics interfering.