### PR TITLE
Remove "misuse-resistant"

### DIFF
--- a/LIZENZ
+++ b/LIZENZ
@@ -1,4 +1,4 @@
-rio, a pure-rust misuse-resistant io_uring library.
+rio, a pure-rust io_uring library.
 Copyright (C) 2020 Tyler Neely
 
 This program is free software: you can redistribute it and/or modify

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # rio
 
-misuse-resistant bindings for io_uring, the hottest
+bindings for io_uring, the hottest
 thing to happen to linux IO in a long time.
 
 #### Innovations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,18 +17,17 @@
 //! will all be in scope at the same time while the Completion
 //! is in-use.
 //!
-//! This library aims to be misuse-resistant.
 //! Most of the other io_uring libraries make
 //! it really easy to blow your legs off with
 //! use-after-frees. `rio` uses standard Rust
-//! lifetime specification  to make use-after-frees
+//! lifetime specification  to make most use-after-frees
 //! fail to compile. Also, if a `Completion`
 //! that was pinned to the lifetime of a uring
 //! and backing buffer is dropped, it
 //! waits for its backing operation to complete
 //! before returning from Drop, to further
 //! prevent use-after-frees. use-after-frees
-//! are not expressible when using `rio`.
+//! are difficult to express when using `rio`.
 //!
 //! # Examples
 //!


### PR DESCRIPTION
Based on #11, this does not appear to be a goal of this library, at least in the way I would assume.