### PR TITLE
Document soundness status

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -32,10 +32,11 @@ impl Default for CompletionState {
 ///
 /// # Safety
 ///
-/// Never call `std::mem::forget` on this value.
-/// It can lead to a use-after-free bug. The fact
-/// that `std::mem::forget` is not marked unsafe
-/// is a bug in the Rust standard library.
+/// To prevent undefined behavior in the form of
+/// use-after-free, never allow a Completion's
+/// lifetime to end without dropping it. This can
+/// happen with `std::mem::forget`, cycles in
+/// `Arc` or `Rc`, and in other ways.
 #[derive(Debug)]
 pub struct Completion<'a, C: FromCqe> {
     lifetime: PhantomData<&'a C>,


### PR DESCRIPTION
I know it's been a while since there was a commit to this project, but I also know people are still on your case about this, and my hope is that full transparency will get them off of it. I'm also keeping in mind that you asked for a pull request in #30.

You'll need to publish a new version to crates.io, even if there have been no code changes, in order to make the textual changes since the last published version visible there and on docs.rs.