### PR TITLE
Update submitted atomic in submit_all()

### DIFF
--- a/src/io_uring/uring.rs
+++ b/src/io_uring/uring.rs
@@ -675,7 +675,9 @@ impl Uring {
             self.sq.lock().unwrap()
         };
         let _hold_sq_mu = Measure::new(&M.sq_mu_hold);
-        sq.submit_all(self.flags, self.ring_fd);
+        let submitted =
+            sq.submit_all(self.flags, self.ring_fd);
+        self.submitted.fetch_add(submitted, Release);
     }
 
     fn with_sqe<'a, F, C>(


### PR DESCRIPTION
If the user calls submit_all() directly, the submitted atomic is not
updated.  Leading to a crash.  I suspect most users rely on waiting on
a completion to implicitly submit so don't hit this issue.